### PR TITLE
refactor: 💡 Extract common functionality into separate functions

### DIFF
--- a/scripts/startRelease.js
+++ b/scripts/startRelease.js
@@ -4,13 +4,122 @@ const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 const releaseType = process.argv[2];
 const semanticVersionType = process.argv[3];
 
-async function createCanaryRelease() {
-  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-
+async function getReleases(owner, repo) {
   const releases = await octokit.paginate(octokit.repos.listReleases, {
     owner,
     repo,
   });
+  return releases;
+}
+
+async function getMergedPullRequests(owner, repo, published_at) {
+  const pullRequests = await octokit.paginate(octokit.pulls.list, {
+    owner,
+    repo,
+    state: "closed",
+  });
+  const mergedPullRequests = pullRequests.filter(
+    (pr) => pr.merged_at && new Date(pr.merged_at) > new Date(published_at || 0)
+  );
+  return mergedPullRequests;
+}
+
+function groupPullRequestsByLabel(pullRequests) {
+  let coreChanges = [];
+  let documentationChanges = [];
+  let miscellaneousChanges = [];
+
+  for (const pr of pullRequests) {
+    if (pr.labels.some((label) => label.name === "area:core")) {
+      coreChanges.push(pr);
+    } else if (pr.labels.some((label) => label.name === "area:documentation")) {
+      documentationChanges.push(pr);
+    } else {
+      miscellaneousChanges.push(pr);
+    }
+  }
+
+  return { coreChanges, documentationChanges, miscellaneousChanges };
+}
+
+function generateReleaseNotes(
+  coreChanges,
+  documentationChanges,
+  miscellaneousChanges
+) {
+  let releaseNotes = "";
+
+  if (coreChanges.length > 0) {
+    releaseNotes += "## Core Changes\n";
+
+    for (const pr of coreChanges) {
+      releaseNotes += `- ${pr.title}: #${pr.number}\n`;
+    }
+
+    releaseNotes += "\n";
+  }
+
+  if (documentationChanges.length > 0) {
+    releaseNotes += "## Documentation Changes\n";
+
+    for (const pr of documentationChanges) {
+      releaseNotes += `- ${pr.title}: #${pr.number}\n`;
+    }
+
+    releaseNotes += "\n";
+  }
+
+  if (miscellaneousChanges.length > 0) {
+    releaseNotes += "## Miscellaneous Changes\n";
+
+    for (const pr of miscellaneousChanges) {
+      releaseNotes += `- ${pr.title}: #${pr.number}\n`;
+    }
+
+    releaseNotes += "\n";
+  }
+
+  return releaseNotes;
+}
+
+function generateContributorsList(mergedPullRequests) {
+  let contributors = new Set();
+
+  for (const pr of mergedPullRequests) {
+    contributors.add(pr.user?.login);
+  }
+
+  let contributorsList = "";
+
+  if (contributors.size > 0) {
+    contributorsList += "## Contributors\n";
+    contributorsList += "A big thank you to our ";
+    let contributorsArray = Array.from(contributors);
+
+    if (contributorsArray.length === 1) {
+      contributorsList += `contributor @${contributorsArray[0]}.`;
+    } else {
+      contributorsList += "contributors ";
+
+      for (const [index, contributor] of contributorsArray.entries()) {
+        if (index === contributorsArray.length - 1) {
+          contributorsList += `and @${contributor}.`;
+        } else {
+          contributorsList += `@${contributor}, `;
+        }
+      }
+    }
+
+    contributorsList += "\n";
+  }
+
+  return contributorsList;
+}
+
+async function createCanaryRelease() {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+  const releases = await getReleases(owner, repo);
   const latestRelease = releases[0];
   let tag_name = `v0.0.0-canary.0`;
   let releaseNotes = "";
@@ -46,15 +155,10 @@ async function createCanaryRelease() {
       }
     }
     // Get merged pull requests between latest release and new canary release
-    const pullRequests = await octokit.paginate(octokit.pulls.list, {
+    const mergedPullRequests = await getMergedPullRequests(
       owner,
       repo,
-      state: "closed",
-    });
-    const mergedPullRequests = pullRequests.filter(
-      (pr) =>
-        pr.merged_at &&
-        new Date(pr.merged_at) > new Date(latestRelease.published_at || 0)
+      latestRelease.published_at
     );
 
     // Guard clause: No merged pull requests
@@ -66,75 +170,25 @@ async function createCanaryRelease() {
     }
 
     // Group pull requests by label
-    const coreChanges = [];
-    const documentationChanges = [];
-    const miscellaneousChanges = [];
-    for (const pr of mergedPullRequests) {
-      if (pr.labels.some((label) => label.name === "area:core")) {
-        coreChanges.push(pr);
-      } else if (
-        pr.labels.some((label) => label.name === "area:documentation")
-      ) {
-        documentationChanges.push(pr);
-      } else {
-        miscellaneousChanges.push(pr);
-      }
-    }
+    const { coreChanges, documentationChanges, miscellaneousChanges } =
+      groupPullRequestsByLabel(mergedPullRequests);
+
     // Generate release notes
-    if (coreChanges.length > 0) {
-      releaseNotes += "## Core Changes\n";
-      for (const pr of coreChanges) {
-        releaseNotes += `- ${pr.title}: #${pr.number}\n`;
-      }
-    }
-    if (documentationChanges.length > 0) {
-      releaseNotes += "## Documentation Changes\n";
-      for (const pr of documentationChanges) {
-        releaseNotes += `- ${pr.title}: #${pr.number}\n`;
-      }
-    }
-    if (miscellaneousChanges.length > 0) {
-      releaseNotes += "## Miscellaneous Changes\n";
-      for (const pr of miscellaneousChanges) {
-        releaseNotes += `- ${pr.title}: #${pr.number}\n`;
-      }
-    }
+    releaseNotes += generateReleaseNotes(
+      coreChanges,
+      documentationChanges,
+      miscellaneousChanges
+    );
+
     // Generate list of contributors
-    const contributors = new Set();
-    for (const pr of mergedPullRequests) {
-      contributors.add(pr.user?.login);
-    }
-    if (contributors.size > 0) {
-      releaseNotes += "## Contributors\n";
-      releaseNotes += "A big thank you to our ";
-      const contributorsArray = Array.from(contributors);
-      if (contributorsArray.length === 1) {
-        releaseNotes += `contributor @${contributorsArray[0]}.`;
-      } else {
-        releaseNotes += "contributors ";
-        for (const [index, contributor] of contributorsArray.entries()) {
-          if (index === contributorsArray.length - 1) {
-            releaseNotes += `and @${contributor}.`;
-          } else {
-            releaseNotes += `@${contributor}, `;
-          }
-        }
-      }
-    }
-  } else {
-    // No releases found for repository
-    switch (semanticVersionType) {
-      case "major":
-        tag_name = `v1.0.0-canary.0`;
-        break;
-      case "minor":
-        tag_name = `v0.1.0-canary.0`;
-        break;
-      case "patch":
-        tag_name = `v0.0.1-canary.0`;
-        break;
-    }
-  };
+    releaseNotes += generateContributorsList(mergedPullRequests);
+  }
+
+  if (!latestRelease) {
+    console.log("No releases found for repository");
+    return;
+  }
+
   const name = `${tag_name}`;
   const body = `New canary release based on ${latestRelease.tag_name}\n\n${releaseNotes}`;
   await octokit.repos.createRelease({
@@ -150,10 +204,7 @@ async function createCanaryRelease() {
 async function createRelease() {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
 
-  const releases = await octokit.paginate(octokit.repos.listReleases, {
-    owner,
-    repo,
-  });
+  const releases = await getReleases(owner, repo);
   const latestCanaryRelease = releases.find((release) =>
     release.tag_name.includes("canary")
   );
@@ -174,15 +225,10 @@ async function createRelease() {
 
   // Get merged pull requests between first canary release and new release
   const firstCanaryRelease = canaryReleases[canaryReleases.length - 1];
-  const pullRequests = await octokit.paginate(octokit.pulls.list, {
+  const mergedPullRequests = await getMergedPullRequests(
     owner,
     repo,
-    state: "closed",
-  });
-  const mergedPullRequests = pullRequests.filter(
-    (pr) =>
-      pr.merged_at &&
-      new Date(pr.merged_at) > new Date(firstCanaryRelease.published_at || 0)
+    firstCanaryRelease.published_at
   );
 
   // Guard clause: No merged pull requests
@@ -194,81 +240,18 @@ async function createRelease() {
   }
 
   // Group pull requests by label
-  let coreChanges = [];
-  let documentationChanges = [];
-  let miscellaneousChanges = [];
-
-  for (const pr of mergedPullRequests) {
-    if (pr.labels.some((label) => label.name === "area:core")) {
-      coreChanges.push(pr);
-    } else if (pr.labels.some((label) => label.name === "area:documentation")) {
-      documentationChanges.push(pr);
-    } else {
-      miscellaneousChanges.push(pr);
-    }
-  }
+  const { coreChanges, documentationChanges, miscellaneousChanges } =
+    groupPullRequestsByLabel(mergedPullRequests);
 
   // Generate release notes
-  let releaseNotes = "";
-
-  if (coreChanges.length > 0) {
-    releaseNotes += "## Core Changes\n";
-
-    for (const pr of coreChanges) {
-      releaseNotes += `- ${pr.title}: #${pr.number}\n`;
-    }
-
-    releaseNotes += "\n";
-  }
-
-  if (documentationChanges.length > 0) {
-    releaseNotes += "## Documentation Changes\n";
-
-    for (const pr of documentationChanges) {
-      releaseNotes += `- ${pr.title}: #${pr.number}\n`;
-    }
-
-    releaseNotes += "\n";
-  }
-
-  if (miscellaneousChanges.length > 0) {
-    releaseNotes += "## Miscellaneous Changes\n";
-
-    for (const pr of miscellaneousChanges) {
-      releaseNotes += `- ${pr.title}: #${pr.number}\n`;
-    }
-
-    releaseNotes += "\n";
-  }
+  let releaseNotes = generateReleaseNotes(
+    coreChanges,
+    documentationChanges,
+    miscellaneousChanges
+  );
 
   // Generate list of contributors
-  let contributors = new Set();
-
-  for (const pr of mergedPullRequests) {
-    contributors.add(pr.user?.login);
-  }
-
-  if (contributors.size > 0) {
-    releaseNotes += "## Contributors\n";
-    releaseNotes += "A big thank you to our ";
-    let contributorsArray = Array.from(contributors);
-
-    if (contributorsArray.length === 1) {
-      releaseNotes += `contributor @${contributorsArray[0]}.`;
-    } else {
-      releaseNotes += "contributors ";
-
-      for (const [index, contributor] of contributorsArray.entries()) {
-        if (index === contributorsArray.length - 1) {
-          releaseNotes += `and @${contributor}.`;
-        } else {
-          releaseNotes += `@${contributor}, `;
-        }
-      }
-    }
-
-    releaseNotes += "\n";
-  }
+  releaseNotes += generateContributorsList(mergedPullRequests);
 
   await octokit.repos.createRelease({
     owner,


### PR DESCRIPTION
Extract common functionality for retrieving releases and pull requests, grouping pull requests by label, generating release notes and listing contributors into separate functions to reduce code duplication between createCanaryRelease and createRelease functions.