### PR TITLE
bugfix: 🐛 update regex to match canary.0

### DIFF
--- a/scripts/startRelease.js
+++ b/scripts/startRelease.js
@@ -220,7 +220,7 @@ async function createRelease() {
   // Get all canary releases of the same version
   const version = tag_name.substring(1);
   const canaryReleases = releases.filter((release) =>
-    new RegExp(`^v${version}(-canary\\.\\d+)?$`).test(release.tag_name)
+    new RegExp(`^v${version}(-canary\\.\\d*)?$`).test(release.tag_name)
   );
 
   // Get merged pull requests between first canary release and new release


### PR DESCRIPTION
This commit fixes a bug in the code by updating the regular expression to match strings that end with -canary.0.