### PR TITLE
fix: 🐛 add missing tag_name variable

### DIFF
--- a/scripts/startRelease.js
+++ b/scripts/startRelease.js
@@ -289,6 +289,8 @@ async function createRelease() {
     return;
   }
 
+  const tag_name = latestCanaryRelease.tag_name.split("-canary")[0];
+
   const lastStableRelease = await getLastStableRelease(owner, repo);
 
   const mergedPullRequests = await getMergedPullRequests(


### PR DESCRIPTION
This commit fixes a bug in the code by adding the missing tag_name variable. The tag_name variable is used to store the tag name of the latest canary release without the -canary.X suffix.