### PR TITLE
fix: 🐛 restore missing name variable

### DIFF
--- a/scripts/startRelease.js
+++ b/scripts/startRelease.js
@@ -293,6 +293,7 @@ async function createRelease() {
   }
 
   const tag_name = latestCanaryRelease.tag_name.split("-canary")[0];
+  const name = `${tag_name}`;
 
   const lastStableRelease = await getLastStableRelease(owner, repo);
 


### PR DESCRIPTION
This commit restores the name variable that was removed during a refactor. The variable is now present and the bug is fixed.